### PR TITLE
✅ Add .NET Application layer unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,27 @@ jobs:
           cd backend/nestjs
           npm test
 
+  build-and-test-backend-dotnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore Dependencies
+        run: |
+          cd backend/dotnet/src/TaskManager
+          dotnet restore
+      - name: Build
+        run: |
+          cd backend/dotnet/src/TaskManager
+          dotnet build --no-restore
+      - name: Run Tests
+        run: |
+          cd backend/dotnet/src/TaskManager
+          dotnet test --no-build --verbosity normal
+
   build-and-test-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/backend/dotnet/src/TaskManager/Application.Tests/Service/TaskServiceTests.cs
+++ b/backend/dotnet/src/TaskManager/Application.Tests/Service/TaskServiceTests.cs
@@ -1,0 +1,596 @@
+using FluentAssertions;
+using Moq;
+using TaskManager.Application.Interface;
+using TaskManager.Application.Service;
+using TaskManager.Domain.Models;
+
+namespace TaskManager.Application.Tests.Service;
+
+public class TaskServiceTests
+{
+    private readonly Mock<ITaskRepository> _taskRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly TaskService _sut;
+
+    public TaskServiceTests()
+    {
+        _taskRepositoryMock = new Mock<ITaskRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _sut = new TaskService(_taskRepositoryMock.Object, _userRepositoryMock.Object);
+    }
+
+    #region GetAllTasksAsync
+
+    [Fact]
+    public async Task GetAllTasksAsync_ShouldReturnAllTasks()
+    {
+        // Arrange
+        var tasks = new List<TaskDomain>
+        {
+            new() { Id = Guid.NewGuid(), Title = "Task 1" },
+            new() { Id = Guid.NewGuid(), Title = "Task 2" }
+        };
+        _taskRepositoryMock.Setup(r => r.FindAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tasks);
+
+        // Act
+        var result = await _sut.GetAllTasksAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(tasks);
+        _taskRepositoryMock.Verify(r => r.FindAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllTasksAsync_WhenNoTasks_ShouldReturnEmptyList()
+    {
+        // Arrange
+        _taskRepositoryMock.Setup(r => r.FindAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TaskDomain>());
+
+        // Act
+        var result = await _sut.GetAllTasksAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region GetTasksByStatusAsync
+
+    [Fact]
+    public async Task GetTasksByStatusAsync_ShouldReturnFilteredTasks()
+    {
+        // Arrange
+        var tasks = new List<TaskDomain>
+        {
+            new() { Id = Guid.NewGuid(), Title = "Task 1", Status = "TODO" }
+        };
+        _taskRepositoryMock.Setup(r => r.FindByStatusAsync("TODO", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tasks);
+
+        // Act
+        var result = await _sut.GetTasksByStatusAsync("TODO", CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(tasks);
+    }
+
+    #endregion
+
+    #region GetTasksByAssigneeAsync
+
+    [Fact]
+    public async Task GetTasksByAssigneeAsync_WhenUserExists_ShouldReturnTasks()
+    {
+        // Arrange
+        var assigneeId = Guid.NewGuid();
+        var tasks = new List<TaskDomain>
+        {
+            new() { Id = Guid.NewGuid(), Title = "Task 1", AssigneeId = assigneeId }
+        };
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.FindByAssigneeIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tasks);
+
+        // Act
+        var result = await _sut.GetTasksByAssigneeAsync(assigneeId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(tasks);
+    }
+
+    [Fact]
+    public async Task GetTasksByAssigneeAsync_WhenUserNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var assigneeId = Guid.NewGuid();
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _sut.GetTasksByAssigneeAsync(assigneeId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"User not found with ID: {assigneeId}");
+    }
+
+    #endregion
+
+    #region GetTaskByIdAsync
+
+    [Fact]
+    public async Task GetTaskByIdAsync_WhenTaskExists_ShouldReturnTask()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Test Task" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.GetTaskByIdAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(task);
+    }
+
+    [Fact]
+    public async Task GetTaskByIdAsync_WhenTaskNotFound_ShouldReturnNull()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TaskDomain?)null);
+
+        // Act
+        var result = await _sut.GetTaskByIdAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region CreateTaskAsync
+
+    [Fact]
+    public async Task CreateTaskAsync_WithoutAssignee_ShouldResetIdAndSave()
+    {
+        // Arrange
+        var originalId = Guid.NewGuid();
+        var task = new TaskDomain { Id = originalId, Title = "New Task", Description = "Description" };
+        TaskDomain? capturedTask = null;
+
+        _taskRepositoryMock.Setup(r => r.SaveAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.CreateTaskAsync(task, CancellationToken.None);
+
+        // Assert
+        capturedTask.Should().NotBeNull();
+        capturedTask!.Id.Should().BeNull("ID should be reset to null before saving");
+        capturedTask.Title.Should().Be("New Task");
+        capturedTask.Description.Should().Be("Description");
+        _taskRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_WithValidAssignee_ShouldVerifyAssigneeAndSave()
+    {
+        // Arrange
+        var assigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Id = Guid.NewGuid(), Title = "New Task", AssigneeId = assigneeId };
+        TaskDomain? capturedTask = null;
+
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.ExistsByTitleAndAssigneeIdAsync("New Task", assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _taskRepositoryMock.Setup(r => r.SaveAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.CreateTaskAsync(task, CancellationToken.None);
+
+        // Assert
+        _userRepositoryMock.Verify(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()), Times.Once);
+        _taskRepositoryMock.Verify(r => r.ExistsByTitleAndAssigneeIdAsync("New Task", assigneeId, It.IsAny<CancellationToken>()), Times.Once);
+        capturedTask.Should().NotBeNull();
+        capturedTask!.Id.Should().BeNull();
+        capturedTask.AssigneeId.Should().Be(assigneeId);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_WhenAssigneeNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var assigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Title = "New Task", AssigneeId = assigneeId };
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _sut.CreateTaskAsync(task, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Assignee not found with ID: {assigneeId}");
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_WhenDuplicateTitleForAssignee_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var assigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Title = "Duplicate Title", AssigneeId = assigneeId };
+
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.ExistsByTitleAndAssigneeIdAsync("Duplicate Title", assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var act = () => _sut.CreateTaskAsync(task, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("A task with this title already exists for this user");
+    }
+
+    #endregion
+
+    #region UpdateTaskAsync
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenTaskExists_ShouldUpdateProperties()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var originalTask = new TaskDomain
+        {
+            Id = taskId,
+            Title = "Original",
+            Description = "Old Description",
+            Status = "TODO",
+            Priority = "LOW"
+        };
+        var updateTask = new TaskDomain
+        {
+            Title = "Updated",
+            Description = "New Description",
+            Status = "IN_PROGRESS",
+            Priority = "HIGH"
+        };
+        TaskDomain? capturedTask = null;
+
+        _taskRepositoryMock.Setup(r => r.ExistsByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(originalTask);
+        _taskRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.UpdateTaskAsync(taskId, updateTask, CancellationToken.None);
+
+        // Assert
+        capturedTask.Should().NotBeNull();
+        capturedTask!.Id.Should().Be(taskId, "original task ID should be preserved");
+        capturedTask.Title.Should().Be("Updated");
+        capturedTask.Description.Should().Be("New Description");
+        capturedTask.Status.Should().Be("IN_PROGRESS");
+        capturedTask.Priority.Should().Be("HIGH");
+        _taskRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenTaskNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Title = "Update" };
+        _taskRepositoryMock.Setup(r => r.ExistsByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _sut.UpdateTaskAsync(taskId, task, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Task not found with ID: {taskId}");
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenAssigneeNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var assigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Title = "Update", AssigneeId = assigneeId };
+
+        _taskRepositoryMock.Setup(r => r.ExistsByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _sut.UpdateTaskAsync(taskId, task, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Assignee not found with ID: {assigneeId}");
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WhenDuplicateTitleForNewAssignee_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var originalAssigneeId = Guid.NewGuid();
+        var newAssigneeId = Guid.NewGuid();
+        var originalTask = new TaskDomain { Id = taskId, Title = "Task", AssigneeId = originalAssigneeId };
+        var updateTask = new TaskDomain { Title = "Task", AssigneeId = newAssigneeId };
+
+        _taskRepositoryMock.Setup(r => r.ExistsByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(newAssigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(originalTask);
+        _taskRepositoryMock.Setup(r => r.ExistsByTitleAndAssigneeIdAsync("Task", newAssigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var act = () => _sut.UpdateTaskAsync(taskId, updateTask, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("A task with this title already exists for this user");
+    }
+
+    #endregion
+
+    #region AssignTaskAsync
+
+    [Fact]
+    public async Task AssignTaskAsync_WhenValid_ShouldSetAssigneeIdAndUpdate()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var assigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", AssigneeId = null };
+        TaskDomain? capturedTask = null;
+
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _taskRepositoryMock.Setup(r => r.ExistsByTitleAndAssigneeIdAsync("Task", assigneeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _taskRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.AssignTaskAsync(taskId, assigneeId, CancellationToken.None);
+
+        // Assert
+        capturedTask.Should().NotBeNull();
+        capturedTask!.AssigneeId.Should().Be(assigneeId);
+        _userRepositoryMock.Verify(r => r.ExistsByIdAsync(assigneeId, It.IsAny<CancellationToken>()), Times.Once);
+        _taskRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignTaskAsync_WhenTaskNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TaskDomain?)null);
+
+        // Act
+        var act = () => _sut.AssignTaskAsync(taskId, Guid.NewGuid(), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Task not found with ID: {taskId}");
+    }
+
+    [Fact]
+    public async Task AssignTaskAsync_WithNullAssignee_ShouldSetAssigneeToNull()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var originalAssigneeId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", AssigneeId = originalAssigneeId };
+        TaskDomain? capturedTask = null;
+
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+        _taskRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.AssignTaskAsync(taskId, null, CancellationToken.None);
+
+        // Assert
+        capturedTask.Should().NotBeNull();
+        capturedTask!.AssigneeId.Should().BeNull();
+        _userRepositoryMock.Verify(r => r.ExistsByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region UpdateTaskStatusAsync
+
+    [Theory]
+    [InlineData("TODO")]
+    [InlineData("IN_PROGRESS")]
+    [InlineData("DONE")]
+    public async Task UpdateTaskStatusAsync_WithValidStatus_ShouldSetStatusAndUpdate(string status)
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Status = "TODO" };
+        TaskDomain? capturedTask = null;
+
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+        _taskRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()))
+            .Callback<TaskDomain, CancellationToken>((t, _) => capturedTask = t)
+            .ReturnsAsync((TaskDomain t, CancellationToken _) => t);
+
+        // Act
+        await _sut.UpdateTaskStatusAsync(taskId, status, CancellationToken.None);
+
+        // Assert
+        capturedTask.Should().NotBeNull();
+        capturedTask!.Status.Should().Be(status);
+        _taskRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<TaskDomain>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatusAsync_WithInvalidStatus_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var act = () => _sut.UpdateTaskStatusAsync(taskId, "INVALID", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Invalid status: INVALID");
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatusAsync_WhenTaskNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TaskDomain?)null);
+
+        // Act
+        var act = () => _sut.UpdateTaskStatusAsync(taskId, "TODO", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Task not found with ID: {taskId}");
+    }
+
+    #endregion
+
+    #region EstimateTaskTimeAsync
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WithDefaultTask_ShouldReturnBaseHours()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Priority = "MEDIUM", Status = "TODO" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(2.0); // Base hours
+    }
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WithHighPriority_ShouldReturn1_5xBaseHours()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Priority = "HIGH", Status = "TODO" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(3.0); // 2.0 * 1.5
+    }
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WithLowPriority_ShouldReturn0_75xBaseHours()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Priority = "LOW", Status = "TODO" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(1.5); // 2.0 * 0.75
+    }
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WhenInProgress_ShouldReturn0_7xHours()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Priority = "MEDIUM", Status = "IN_PROGRESS" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(1.4); // 2.0 * 0.7
+    }
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WhenDone_ShouldReturnMinimum()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new TaskDomain { Id = taskId, Title = "Task", Status = "DONE" };
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(task);
+
+        // Act
+        var result = await _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0.25); // Minimum 15 minutes
+    }
+
+    [Fact]
+    public async Task EstimateTaskTimeAsync_WhenTaskNotFound_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        _taskRepositoryMock.Setup(r => r.FindByIdAsync(taskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TaskDomain?)null);
+
+        // Act
+        var act = () => _sut.EstimateTaskTimeAsync(taskId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"Task not found with ID: {taskId}");
+    }
+
+    #endregion
+}

--- a/backend/dotnet/src/TaskManager/Application.Tests/Service/UserServiceTests.cs
+++ b/backend/dotnet/src/TaskManager/Application.Tests/Service/UserServiceTests.cs
@@ -1,0 +1,375 @@
+using FluentAssertions;
+using Moq;
+using TaskManager.Application.Interface;
+using TaskManager.Application.Service;
+using TaskManager.Domain.Models;
+
+namespace TaskManager.Application.Tests.Service;
+
+public class UserServiceTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly UserService _sut;
+
+    public UserServiceTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _sut = new UserService(_userRepositoryMock.Object);
+    }
+
+    #region GetAllUsersAsync
+
+    [Fact]
+    public async Task GetAllUsersAsync_ShouldReturnAllUsers()
+    {
+        // Arrange
+        var users = new List<User>
+        {
+            new() { Id = Guid.NewGuid(), Username = "user1" },
+            new() { Id = Guid.NewGuid(), Username = "user2" }
+        };
+        _userRepositoryMock.Setup(r => r.FindAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+
+        // Act
+        var result = await _sut.GetAllUsersAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(users);
+        _userRepositoryMock.Verify(r => r.FindAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllUsersAsync_WhenNoUsers_ShouldReturnEmptyList()
+    {
+        // Arrange
+        _userRepositoryMock.Setup(r => r.FindAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<User>());
+
+        // Act
+        var result = await _sut.GetAllUsersAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region GetUserByIdAsync
+
+    [Fact]
+    public async Task GetUserByIdAsync_WhenUserExists_ShouldReturnUser()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Username = "testuser" };
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _sut.GetUserByIdAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(user);
+    }
+
+    [Fact]
+    public async Task GetUserByIdAsync_WhenUserNotFound_ShouldReturnNull()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _sut.GetUserByIdAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetUserByUsernameAsync
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_WhenUserExists_ShouldReturnUser()
+    {
+        // Arrange
+        var user = new User { Id = Guid.NewGuid(), Username = "testuser" };
+        _userRepositoryMock.Setup(r => r.FindByUsernameAsync("testuser", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _sut.GetUserByUsernameAsync("testuser", CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(user);
+    }
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_WhenUserNotFound_ShouldReturnNull()
+    {
+        // Arrange
+        _userRepositoryMock.Setup(r => r.FindByUsernameAsync("unknown", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _sut.GetUserByUsernameAsync("unknown", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region CreateUserAsync
+
+    [Fact]
+    public async Task CreateUserAsync_WithUniqueUsername_ShouldResetIdAndSave()
+    {
+        // Arrange
+        var originalId = Guid.NewGuid();
+        var user = new User { Id = originalId, Username = "newuser", Email = "new@test.com", Role = "user" };
+        User? capturedUser = null;
+
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("newuser", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _userRepositoryMock.Setup(r => r.SaveAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => capturedUser = u)
+            .ReturnsAsync((User u, CancellationToken _) => u);
+
+        // Act
+        await _sut.CreateUserAsync(user, CancellationToken.None);
+
+        // Assert
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Id.Should().BeNull("ID should be reset to null before saving");
+        capturedUser.Username.Should().Be("newuser");
+        capturedUser.Email.Should().Be("new@test.com");
+        capturedUser.Role.Should().Be("user");
+        _userRepositoryMock.Verify(r => r.ExistsByUsernameAsync("newuser", It.IsAny<CancellationToken>()), Times.Once);
+        _userRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_WithDuplicateUsername_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var user = new User { Username = "existinguser" };
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("existinguser", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var act = () => _sut.CreateUserAsync(user, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("A user with this username already exists");
+        _userRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_WithNullUsername_ShouldSkipUniquenessCheckAndSave()
+    {
+        // Arrange
+        var user = new User { Id = Guid.NewGuid(), Email = "test@test.com" };
+        User? capturedUser = null;
+
+        _userRepositoryMock.Setup(r => r.SaveAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => capturedUser = u)
+            .ReturnsAsync((User u, CancellationToken _) => u);
+
+        // Act
+        await _sut.CreateUserAsync(user, CancellationToken.None);
+
+        // Assert
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Id.Should().BeNull();
+        capturedUser.Email.Should().Be("test@test.com");
+        _userRepositoryMock.Verify(r => r.ExistsByUsernameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _userRepositoryMock.Verify(r => r.SaveAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region UpdateUserAsync
+
+    [Fact]
+    public async Task UpdateUserAsync_WhenUserExists_ShouldUpdateProperties()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var originalUser = new User { Id = userId, Username = "original", Email = "original@test.com", Role = "user" };
+        var updateUser = new User { Username = "updated", Email = "updated@test.com", Role = "admin" };
+        User? capturedUser = null;
+
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(originalUser);
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("updated", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _userRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => capturedUser = u)
+            .ReturnsAsync((User u, CancellationToken _) => u);
+
+        // Act
+        await _sut.UpdateUserAsync(userId, updateUser, CancellationToken.None);
+
+        // Assert
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Id.Should().Be(userId, "original user ID should be preserved");
+        capturedUser.Username.Should().Be("updated");
+        capturedUser.Email.Should().Be("updated@test.com");
+        capturedUser.Role.Should().Be("admin");
+        _userRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_WhenUserNotFound_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = new User { Username = "update" };
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _sut.UpdateUserAsync(userId, user, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"User not found with ID: {userId}");
+        _userRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_WithDuplicateUsername_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var originalUser = new User { Id = userId, Username = "original" };
+        var updateUser = new User { Username = "taken" };
+
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(originalUser);
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("taken", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var act = () => _sut.UpdateUserAsync(userId, updateUser, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("A user with this username already exist");
+        _userRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_WithSameUsername_ShouldSkipUniquenessCheckAndUpdate()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var originalUser = new User { Id = userId, Username = "same", Email = "old@test.com" };
+        var updateUser = new User { Username = "same", Email = "new@test.com" };
+        User? capturedUser = null;
+
+        _userRepositoryMock.Setup(r => r.ExistsByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(originalUser);
+        _userRepositoryMock.Setup(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => capturedUser = u)
+            .ReturnsAsync((User u, CancellationToken _) => u);
+
+        // Act
+        await _sut.UpdateUserAsync(userId, updateUser, CancellationToken.None);
+
+        // Assert
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Email.Should().Be("new@test.com");
+        _userRepositoryMock.Verify(r => r.ExistsByUsernameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _userRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteUserAsync
+
+    [Fact]
+    public async Task DeleteUserAsync_WhenUserExists_ShouldDeleteCorrectUserAndReturnTrue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Username = "todelete" };
+        User? capturedUser = null;
+
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _userRepositoryMock.Setup(r => r.DeleteByIdAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => capturedUser = u);
+
+        // Act
+        var result = await _sut.DeleteUserAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Id.Should().Be(userId);
+        capturedUser.Username.Should().Be("todelete");
+        _userRepositoryMock.Verify(r => r.DeleteByIdAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteUserAsync_WhenUserNotFound_ShouldReturnFalseWithoutDeleting()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _userRepositoryMock.Setup(r => r.FindByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _sut.DeleteUserAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+        _userRepositoryMock.Verify(r => r.DeleteByIdAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region ExistsByUsernameAsync
+
+    [Fact]
+    public async Task ExistsByUsernameAsync_WhenUsernameExists_ShouldReturnTrue()
+    {
+        // Arrange
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("existing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _sut.ExistsByUsernameAsync("existing", CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsByUsernameAsync_WhenUsernameNotExists_ShouldReturnFalse()
+    {
+        // Arrange
+        _userRepositoryMock.Setup(r => r.ExistsByUsernameAsync("nonexisting", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _sut.ExistsByUsernameAsync("nonexisting", CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+}

--- a/backend/dotnet/src/TaskManager/Application.Tests/TaskManager.Application.Tests.csproj
+++ b/backend/dotnet/src/TaskManager/Application.Tests/TaskManager.Application.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Application\TaskManager.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/dotnet/src/TaskManager/Application/TaskManager.Application.csproj
+++ b/backend/dotnet/src/TaskManager/Application/TaskManager.Application.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TaskManager.Application.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
   </ItemGroup>
 

--- a/backend/dotnet/src/TaskManager/TaskManager.sln
+++ b/backend/dotnet/src/TaskManager/TaskManager.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.36105.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskManager.Api", "Api\TaskManager.Api.csproj", "{8C1FA268-CEAC-4D64-9D6A-7310A006E36B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskManager.API", "Api\TaskManager.API.csproj", "{8C1FA268-CEAC-4D64-9D6A-7310A006E36B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4EC463C6-9900-496E-9D08-0D76C3FC639F} = {4EC463C6-9900-496E-9D08-0D76C3FC639F}
 	EndProjectSection
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskManager.Infrastructure"
 	ProjectSection(ProjectDependencies) = postProject
 		{4EC463C6-9900-496E-9D08-0D76C3FC639F} = {4EC463C6-9900-496E-9D08-0D76C3FC639F}
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskManager.Application.Tests", "Application.Tests\TaskManager.Application.Tests.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,6 +44,10 @@ Global
 		{62CBFD71-14E1-4F2E-95A5-CEE18DFB735E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62CBFD71-14E1-4F2E-95A5-CEE18DFB735E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62CBFD71-14E1-4F2E-95A5-CEE18DFB735E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- create TaskManager.Application.Tests project with xUnit, Moq, FluentAssertions
- add TaskServiceTests with 32 tests covering CRUD and business logic
- add UserServiceTests with 14 tests covering CRUD operations
- add InternalsVisibleTo to Application project for test access
- register test project in solution file